### PR TITLE
Add logic for determining which relations are ambiguous to schema spec

### DIFF
--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -692,6 +692,38 @@ Disambiguates relationships when needed.
 
 There can be multiple distinct relationships between two models, or between a model and itself ("self relation"). When this is the case, the relationships must be named, so they can be distinguished. Relation fields that do not clearly belong to a specific relationship constitute an *ambiguous relation*.
 
+This is an example ambiguous relation on the schema of an imaginary simplified blogging platform:
+
+```groovy
+model Blog {
+    id          Int @id
+    authors     User[]
+    subscribers User[]
+}
+
+model User  {
+    id           Int @id
+    authorOf     Blog[]
+    subscribedTo Blog[]
+}
+```
+
+There are two relationships between `Blog` and `User`, so we need to name them to tell them apart. A valid version of this schema could look like this:
+
+```groovy
+model Blog {
+    id          Int @id
+    authors     User[] @relation("Authorship")
+    subscribers User[] @relation("Subscription")
+}
+
+model User  {
+    id           Int @id
+    authorOf     Blog[] @relation("Authorship")
+    subscribedTo Blog[] @relation("Subscription")
+}
+```
+
 ###### Arguments
 
 - name: _(optional, except when required for disambiguation)_ defines the name of the relationship. The name of the relation needs to be explicitly given to resolve amibiguities when the model contains two or more fields that refer to the same model (another model or itself).

--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -46,6 +46,8 @@ The Prisma Schema declaratively describes the structure of your data sources. We
         - [@map(\_ name: String)](#map%5C_-name-string)
         - [@default(\_ expr: Expr)](#default%5C_-expr-expr)
         - [@relation(\_ name?: String, references?: Identifier[], onDelete?: CascadeEnum)](#relation%5C_-name-string-references-identifier-ondelete-cascadeenum)
+          - [Arguments](#arguments)
+          - [Validation](#validation)
         - [@updatedAt](#updatedat)
       - [Block Attributes](#block-attributes)
       - [Core Block Attributes](#core-block-attributes)

--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -688,11 +688,21 @@ Specifies a default value if null is provided
 
 Disambiguates relationships when needed
 
-- name: _(optional)_ defines the name of the relationship
+###### Arguments
+
+- name: _(optional, except when required for disambiguation)_ defines the name of the relationship. The name needs to be disambiguated in the following cases:
+  - There is more than one relation between two types.
+  - The relation is a self-relation with two fields.
 - references: _(optional)_ list of field names to reference
 - onDelete: _(optional)_ defines what we do when the referenced relation is deleted
   - **CASCADE**: also delete this entry
   - **SET_NULL**: set the field to null. This is the default
+
+###### Validation
+
+- Ambiguous relations: when one model contains two fields with an `@relation` directive pointing to another model, and both fields have the same relation name, or no relation name, the relation cannot be resolved and a validation error is emitted.
+- Ambiguous self relations: when one model contains two fields referencing the model itself without relation name to disambiguate that they should be seen as the same relation, they are considered ambiguous.
+- Named self relations with more than two fields are rejected, because there is no way to interpret them that makes sense.
 
 ##### @updatedAt
 

--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -688,13 +688,13 @@ Specifies a default value if null is provided
 
 ##### @relation(\_ name?: String, references?: Identifier[], onDelete?: CascadeEnum)
 
-Disambiguates relationships when needed
+Disambiguates relationships when needed.
+
+There can be multiple distinct relationships between two models, or between a model and itself ("self relation"). When this is the case, the relationships must be named, so they can be distinguished. Relation fields that do not clearly belong to a specific relationship constitute an *ambiguous relation*.
 
 ###### Arguments
 
-- name: _(optional, except when required for disambiguation)_ defines the name of the relationship. The name needs to be disambiguated in the following cases:
-  - There is more than one relation between two types.
-  - The relation is a self-relation with two fields.
+- name: _(optional, except when required for disambiguation)_ defines the name of the relationship. The name of the relation needs to be explicitly given to resolve amibiguities when the model contains two or more fields that refer to the same model (another model or itself).
 - references: _(optional)_ list of field names to reference
 - onDelete: _(optional)_ defines what we do when the referenced relation is deleted
   - **CASCADE**: also delete this entry
@@ -704,7 +704,7 @@ Disambiguates relationships when needed
 
 - Ambiguous relations: when one model contains two fields with an `@relation` directive pointing to another model, and both fields have the same relation name, or no relation name, the relation cannot be resolved and a validation error is emitted.
 - Ambiguous self relations: when one model contains two fields referencing the model itself without relation name to disambiguate that they should be seen as the same relation, they are considered ambiguous.
-- Named self relations with more than two fields are rejected, because there is no way to interpret them that makes sense.
+- Named relations with more than two fields are rejected, because there is no way to interpret them that makes sense.
 
 ##### @updatedAt
 


### PR DESCRIPTION
This engine PR https://github.com/prisma/prisma-engine/pull/82 introduces two changes:

- Fix false positives for the validation on ambiguous relations (this was a bug).
- Make the validation for ambiguous self-relations stricter.  *Some schemas that were valid will be rejected by validation after this change*.

Example schema that is no longer valid:

```
model Human {
  id Int @id
  parent Human
  child Human
}
```

We no longer assume that `parent` and `child` are both ends of the same relation. If that is the desired behaviour, the user now needs to give a name to the relation (e.g. `parent Human @relation("ParentToChild")`).

This PR adds the logic for deciding which relations need to be disambiguated to the schema spec 