### PR TITLE
PSL: env default

### DIFF
--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -62,6 +62,7 @@ your datasources with Lift and administer your data using Studio.
     - [Example with Comments](#example-with-comments)
   - [Enum Block](#enum-block)
   - [Env Function](#env-function)
+    - [Env Function Default](#env-function-default)
     - [Env Function Behavior](#env-function-behavior)
   - [Function](#function)
   - [Auto Formatting](#auto-formatting)

--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -857,11 +857,25 @@ datasource pg {
 }
 ```
 
+### Env Function Default
+
+You can also provide a default if the environment variable is not specified:
+
+> ⚠ This is not implemented yet. See [tracking issue](https://github.com/prisma/prisma2/issues/812)
+
+```prisma
+  provider = "sqlite"
+  url      = env("SQLITE_PATH", default: "file.db")
+```
+
+The `provider` must be static and cannot be an environment variable. Our general philosophy is that you want to generate environment variables **as late as
+possible**. The sections below describe this behavior.
+
 ### Env Function Behavior
 
-> ⚠ This is not implemented yet. See [tracking issue](https://github.com/prisma/prisma2/issues/800)
-
 Only functionality that actually requires the environment variable to be set will fail if it is missing. E.g. `generate` will **not** require the environment variable:
+
+> ⚠ This is not implemented yet. See [tracking issue](https://github.com/prisma/prisma2/issues/800)
 
 ```sh
 $ prisma generate


### PR DESCRIPTION
The content of this PR was removed from the PSL spec in https://github.com/prisma/specs/pull/415 and adds it back. 

When #415 is merged, this PR should probably be rebased onto `master`.