### PR TITLE
PSL: Generator Namespaces

### DIFF
--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -125,6 +125,26 @@ generator go {
 
 Generators may bring their own attributes.
 
+### Generator Namespaces
+
+Generator blocks also generate a namespace. This namespace allows fine-grained control over how a model generates it's types:
+
+```prisma
+generate go {
+  snakeCase = true
+  provider  = "go"
+}
+
+type UUID String @go.type("uuid.UUID")
+
+model User {
+  id     UUID    @id
+  email  String  @go.bytes(100)
+}
+```
+
+This namespace is determined by the capabilities of the generator. The generator will export a schema of capabilities we'll plug into.
+
 ### Binary Configuration
 
 ```prisma

--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -19,6 +19,7 @@ your datasources with Lift and administer your data using Studio.
     - [Supported fields](#supported-fields)
   - [Generator Block](#generator-block)
     - [Supported fields](#supported-fields-1)
+    - [Generator Namespaces](#generator-namespaces)
     - [Binary Configuration](#binary-configuration)
   - [Model Block](#model-block)
     - [Field Names](#field-names)


### PR DESCRIPTION
The content of this PR was removed from the PSL spec in https://github.com/prisma/specs/pull/415 and adds it back. 

When #415 is merged, this PR should probably be rebased onto `master`.