### PR TITLE
fix(schema): Fix "Referencing fields that are not @id" model

### DIFF
--- a/schema/Readme.md
+++ b/schema/Readme.md
@@ -582,6 +582,7 @@ model Document {
   projectID  String   @default('')
   revision   Int      @default(1)
   blocks     Block[]
+  @@unique([projectID, revision])
 }
 
 model Block {


### PR DESCRIPTION
Dom pointed out that this model is currently not valid:
https://prisma-company.slack.com/archives/C4GCG53BP/p1584355355339500?thread_ts=1584355345.339400&cid=C4GCG53BP